### PR TITLE
added brotlipy and urllib3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - python
     - future
     - pathlib
+    - brotlipy
     - netcdf4
     - numpy
     - matplotlib-base
@@ -29,6 +30,7 @@ requirements:
     - xarray
     - pyresample
     - python-dateutil
+    - urllib3
     - xmitgcm
     - xgcm
 


### PR DESCRIPTION
yesterday the conda build worked fine.  today it fails on windows systems
```
  File "C:\Miniconda\lib\site-packages\urllib3\connectionpool.py", line 40, in <module>
    from .response import HTTPResponse
  File "C:\Miniconda\lib\site-packages\urllib3\response.py", line 157, in <module>
    class HTTPResponse(io.IOBase):
  File "C:\Miniconda\lib\site-packages\urllib3\response.py", line 390, in HTTPResponse
    DECODER_ERROR_CLASSES += (brotli.error,)
AttributeError: module 'brotli' has no attribute 'error'
```

googling around suggests adding brolipy and urllib3 to the list of required packages.